### PR TITLE
Fix version parsing and comparison for Wine script(now works for 10.0)

### DIFF
--- a/binaries/WabbajackWine.sh
+++ b/binaries/WabbajackWine.sh
@@ -84,11 +84,11 @@ detect_wine_version() {
 	# Which version of wine is installed?
 	wine_binary=$(which wine)
 	echo -e "Wine Binary Path: $wine_binary" >>$LOGFILE 2>&1
-	wine_version=$(wine --version | grep -o '[0-9]\.[0-9]*')
+	wine_version=$(wine --version | grep -oE '[0-9]{1,2}\.[0-9]*')
 
 	echo -e "Wine Version: $wine_version" >>$LOGFILE 2>&1
 
-	if [[ "$wine_version" < "9.15" ]]; then
+    if [ ! "$(printf '%s\n' "9.15" "$wine_version" | sort -V | head -n1)" = "9.15" ]; then
 		echo -e "Wabbajack requires Wine newer than 9.15. Please arrange this on your system and rerun this script."
 		exit 0
 	else


### PR DESCRIPTION
The wine script failed for wine 10.0, saying that the version is lower than 9.15 (when in fact it isn't).

Also fixed the version comparison, which now does it correctly. Previously, 10.0 < 9.15 was showing the "version is lower" message. 