### PR TITLE
Add NixOS flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ Currently, there are two main functions that Jackify will perform at this stage 
 chmod +x Jackify.AppImage
 ./Jackify.AppImage
 ```
+#### NixOS
+
+```bash
+# Add Jackify as a flake input
+# (flake.nix)
+jackify = {
+  url = "github:Omni-guides/Jackify";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+
+# Add Jackify to Home Manager
+# (home.nix)
+home.packages = [
+  inputs.jackify.packages.${pkgs.system}.default
+];
+```
 
 ## Usage
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767379071,
+        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,111 @@
+{
+  description = "Jackify (AppImage) packaged for NixOS with .desktop";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      lib = pkgs.lib;
+
+      # This version and hash must be updated for each new release
+      version = "0.2.0.10";
+
+      # AppImage asset name as published upstream
+      appImageName = "Jackify.AppImage";
+
+      appImage = pkgs.fetchurl {
+        url = "https://github.com/Omni-guides/Jackify/releases/download/v${version}/${appImageName}";
+        # Must be updated when the AppImage changes
+        hash = "sha256-9vfvZC0WcQNlAglPu3hk2hIASWE+EUJ6tlzYdmMdkd0=";
+      };
+
+      # Ensure flake source is a store path for install commands
+      srcTree = builtins.path { path = self; name = "jackify-src"; };
+
+      jackify = pkgs.appimageTools.wrapType2 {
+        pname = "jackify";
+        inherit version;
+        src = appImage;
+
+        extraPkgs = pkgs': with pkgs'; [
+          (python3.withPackages (ps: with ps; [
+            pyside6
+            psutil
+            requests
+            tqdm
+            pycryptodome
+            pyyaml
+            vdf
+            packaging
+          ]))
+          
+          libGL
+          xcb-util-cursor
+          zstd
+          zlib
+          glib
+          openssl
+          xorg.libX11
+          xorg.libXext
+          xorg.libXrender
+          xorg.libXrandr
+          xorg.libxcb
+          libxkbcommon
+          fontconfig
+          freetype
+          gtk3
+          nss
+          nspr
+          fuse3
+        ];
+
+        extraInstallCommands = ''
+          # Icon from repo assets/
+          install -Dm644 ${srcTree}/assets/JackifyLogo_256.png \
+              $out/share/icons/hicolor/256x256/apps/jackify.png
+            
+          # Desktop entry
+          install -Dm644 ${pkgs.writeText "jackify.desktop" ''
+            [Desktop Entry]
+            Type=Application
+            Name=Jackify
+            Comment=Installation and configuration tool for Wabbajack modlists
+            Exec=jackify %U
+            Icon=jackify
+            Terminal=false
+            Categories=Game;Utility;
+            Keywords=Wabbajack;Modlist;Mods;Proton;MO2;
+          ''} \
+            $out/share/applications/jackify.desktop
+        '';
+
+        meta = with lib; {
+          description = "A modlist installation and configuration tool for Wabbajack modlists on Linux";
+          homepage = "https://github.com/Omni-guides/Jackify";
+          license = licenses.gpl3Only;
+          platforms = [ "x86_64-linux" ];
+        };
+      };
+    in {
+        packages.${system} = {
+          jackify = jackify;
+          default = jackify;
+        };
+  
+        apps.${system}.default = {
+          type = "app";
+          program = "${jackify}/bin/jackify";
+        };
+  
+        overlays.default = final: prev: {
+          jackify = jackify;
+        };
+
+        nixosModules.default = { pkgs, ... }: {
+          nixpkgs.overlays = [ self.overlays.default ];
+          environment.systemPackages = [ pkgs.jackify ];
+        };
+      };
+}


### PR DESCRIPTION
This PR adds a Nix flake for packaging the official Jackify AppImage on NixOS.

The flake wraps the upstream AppImage using appimageTools, installs a desktop entry and application icon, and exposes Jackify as a package, app, overlay, and optional NixOS module.

The README has been updated with NixOS (Flakes + Home Manager) installation instructions.

Note: Upstream releases are AppImage only. Updating to a new release requires bumping the version and updating the corresponding fetchurl hash in the flake.

No changes to upstream binaries or application behavior.
